### PR TITLE
Fix/scraping issue when deployed in the cloud

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,7 @@ RUN pip install -e .
 ENV DISPLAY=:99
 
 # Install geckodriver
-RUN GECKODRIVER_VERSION=$(curl -s "https://api.github.com/repos/mozilla/geckodriver/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/') \
-    && wget -O /tmp/geckodriver.tar.gz "https://github.com/mozilla/geckodriver/releases/download/$GECKODRIVER_VERSION/geckodriver-$GECKODRIVER_VERSION-linux64.tar.gz" \
+RUN wget -O /tmp/geckodriver.tar.gz "https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux64.tar.gz" \
     && tar -C /usr/local/bin -xzf /tmp/geckodriver.tar.gz \
     && chmod +x /usr/local/bin/geckodriver \
     && rm /tmp/geckodriver.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12.9-slim
 
 # Installation de Firefox dans le container
-RUN apt-get update && apt-get install wget gnupg curl unzip xvfb -y
+RUN apt-get update && apt-get install wget gnupg -y
 RUN wget -q -O - https://packages.mozilla.org/apt/repo-signing-key.gpg | apt-key add - \
     && echo "deb https://packages.mozilla.org/apt mozilla main" | tee -a /etc/apt/sources.list.d/mozilla.list \
     && apt-get update \
@@ -31,19 +31,7 @@ ADD data/processed/live_commentaires.parquet ./data/processed/live_commentaires.
 COPY pyproject.toml .
 RUN pip install -e .
 
-
-ENV DISPLAY=:99
-
-# Install geckodriver
-RUN wget -O /tmp/geckodriver.tar.gz "https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux64.tar.gz" \
-    && tar -C /usr/local/bin -xzf /tmp/geckodriver.tar.gz \
-    && chmod +x /usr/local/bin/geckodriver \
-    && rm /tmp/geckodriver.tar.gz
-
-# Create a non-root user for security
-RUN groupadd -r selenium && useradd -r -g selenium -G audio,video selenium \
-    && mkdir -p /home/selenium && chown -R selenium:selenium /home/selenium \
-    && chown -R selenium:selenium /kickstarter
+EXPOSE 80
 
 # Commande qui sera lancée au démarrage du container
-CMD ["fastapi", "run", "apps/API.py", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["fastapi", "run", "apps/API.py", "--host", "0.0.0.0", "--port", "80"]

--- a/Makefile
+++ b/Makefile
@@ -26,5 +26,35 @@ download_raw_data_files:
 install:
 	pip install -e .
 
+
+docker_build:
+	docker compose build
+
+gcp_push:
+	docker compose push
+
+gcp_allow:
+	gcloud compute firewall-rules create allow-fastapi   --allow tcp:80   --source-ranges 0.0.0.0/0   --description "Allow FastAPI on port 80"
+
+gcp_instance_ip:
+	gcloud compute instances describe kickstarter-instance-api --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
+
+gcp_deploy:
+	gcloud compute instances create-with-container kickstarter-instance-api 									\
+	--zone=europe-west1-b 																						\
+	--machine-type=e2-small																						\
+	--container-image=europe-west1-docker.pkg.dev/solar-imprint-456810-d6/kickstarter/kickstarter-anatole-fix 	\
+	--tags=http-server 																							\
+	--container-restart-policy=always																			\
+	--container-env ROOT=/kickstarter
+
+instance_ssh:
+	gcloud compute ssh kickstarter-instance-api
+
+cloud:
+	make docker_build
+	make gcp_push
+	make gcp_deploy
+
 test:
 	@echo ${DATA_DIR}

--- a/apps/streamlit_app.py
+++ b/apps/streamlit_app.py
@@ -104,7 +104,8 @@ with tab2:
                     "url": project_url
                 }
 
-        response = requests.get("https://kickstarter-api-195095770000.europe-west1.run.app/predict_by_url", params=params)
+        # response = requests.get("http://kickstarter-api-195095770000.europe-west1.run.app/predict_by_url", params=params)
+        response = requests.get("http://34.77.27.84/predict_by_url", params=params)
 #        response = requests.get("http://localhost:8080/predict_by_url", params=params)
         print(response)
 


### PR DESCRIPTION
Le problème qu'on a eu semble venir de la manière dont les containers gcloud sont montés. Avec une instance compute ça fonctionne.

**Points d'attention**

Les instances gcloud compute sont moins faites pour le web. Notemment au niveau de la partie url. Ici, c'est une adresse ip, qui peut changer si la vm est éteinte ou que google décide de nous les briser. J'ai mis les commandes pour tout relancer dans le Makefile, il n'y a que l'url de scrape de l'API qui a changé, et de toutes les manières, je ne mergerai pas cette pull request, c'est sur votre décision.